### PR TITLE
fix for go rpc not exposing block difficulty

### DIFF
--- a/models/node.js
+++ b/models/node.js
@@ -49,7 +49,7 @@ Node.prototype.update = function()
 
 	if(this.info.stats.peers != null) {
 		this.info.stats.block = eth.block(parseInt(eth.number));
-		if(this.info.stats.block.hash != '?'){
+		if(this.info.stats.block.hash != '?' && typeof this.info.stats.block.difficulty !== 'undefined'){
 			this.info.stats.block.difficulty = this.web3.toDecimal(this.info.stats.block.difficulty);
 		}
 		this.info.stats.mining = eth.mining;


### PR DESCRIPTION
Fixes the error you get when talking to a go client:
```
eth-netstats/node_modules/ethereum.js/lib/web3.js:236
        val = val.length > 2 ? val.substring(2) : "0";
                 ^
TypeError: Cannot read property 'length' of undefined
    at Object.web3.toDecimal (eth-netstats/node_modules/ethereum.js/lib/web3.js:236:18)
    at Node.update (eth-netstats/models/node.js:53:49)
    at Object.<anonymous> (eth-netstats/app.js:38:30)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (eth-netstats/bin/www:3:11)
```