### PR TITLE
Fixed client-side error spam when a node has non-standard node info; updated ws deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config/nodes.js
 *.pem
 .node-xmlhttprequest-*
 ws_secret.json
+stats.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,7 +185,7 @@ module.exports = function(grunt) {
 		concat: {
 			vendor: {
 				options: {
-					sourceMap: true,
+					souceMap: false,
 					sourceMapIncludeSources: true,
 					sourceMapIn: ['dist/js/lib/*.map']
 				},
@@ -201,13 +201,13 @@ module.exports = function(grunt) {
 			},
 			netstats: {
 				options: {
-					sourceMap: true,
+					sourceMap: false,
 					sourceMapIncludeSources: true,
 					sourceMapIn: ['dist/js/vendor.min.js.map', 'dist/js/app.min.js.map']
 				},
 				src: ['<%= concat.vendor.dest %>', '<%= uglify.app.dest %>'],
 				dest: 'dist/js/netstats.min.js',
-				nonull: true,
+				nonull: true
 			},
 			css: {
 				src: ['dist/css/*.min.css', 'dist/css/*.css'],
@@ -215,7 +215,7 @@ module.exports = function(grunt) {
 			},
 			vendor_lite: {
 				options: {
-					sourceMap: true,
+					sourceMap: false,
 					sourceMapIncludeSources: true,
 					sourceMapIn: ['dist-lite/js/lib/*.map']
 				},
@@ -231,7 +231,7 @@ module.exports = function(grunt) {
 			},
 			netstats_lite: {
 				options: {
-					sourceMap: true,
+					sourceMap: false,
 					sourceMapIncludeSources: true,
 					sourceMapIn: ['dist-lite/js/vendor.min.js.map', 'dist-lite/js/app.min.js.map']
 				},
@@ -248,7 +248,7 @@ module.exports = function(grunt) {
 			app: {
 				options: {
 					mangle: false,
-					sourceMap: true,
+					sourceMap: false,
 					sourceMapIncludeSources: true
 				},
 				dest: 'dist/js/app.min.js',
@@ -257,7 +257,7 @@ module.exports = function(grunt) {
 			app_lite: {
 				options: {
 					mangle: false,
-					sourceMap: true,
+					sourceMap: false,
 					sourceMapIncludeSources: true
 				},
 				dest: 'dist-lite/js/app.min.js',

--- a/app.js
+++ b/app.js
@@ -54,8 +54,8 @@ api = new Primus(server, {
 	parser: 'JSON'
 });
 
-api.use('emit', require('primus-emit'));
-api.use('spark-latency', require('primus-spark-latency'));
+api.plugin('emit', require('primus-emit'));
+api.plugin('spark-latency', require('primus-spark-latency'));
 
 
 // Init Client Socket connection
@@ -65,7 +65,7 @@ client = new Primus(server, {
 	parser: 'JSON'
 });
 
-client.use('emit', require('primus-emit'));
+client.plugin('emit', require('primus-emit'));
 
 
 // Init external API
@@ -75,7 +75,7 @@ external = new Primus(server, {
 	parser: 'JSON'
 });
 
-external.use('emit', require('primus-emit'));
+external.plugin('emit', require('primus-emit'));
 
 // Init collections
 var Collection = require('./lib/collection');

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -111,7 +111,7 @@ var ENV_VERBOSITY = process.env.VERBOSITY || 2;
 
 	console[item.name] = function ()
 	{
-		if(verbosity[ENV_VERBOSITY].indexOf(fnName) === -1)
+		if(verbosity[ENV_VERBOSITY].indexOf(item.name) === -1)
 			return false;
 
 		var args = Array.prototype.slice.call(arguments);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "primus": "3.2.1",
     "primus-emit": "0.1.2",
     "primus-spark-latency": "0.1.1",
-    "ws": "0.8.0"
+    "ws": "0.8.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
     "debug": "2.2.0",
     "express": "4.13.3",
     "geoip-lite": "1.1.6",
-    "jade": "1.11.0",
-    "lodash": "3.10.1",
-    "primus": "3.2.1",
-    "primus-emit": "0.1.2",
-    "primus-spark-latency": "0.1.1",
-    "ws": "0.8.1",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jade": "^0.14.1",
-    "grunt-contrib-uglify": "^0.9.1"
+    "grunt-contrib-uglify": "^0.9.1",
+    "jade": "1.11.0",
+    "lodash": "3.10.1",
+    "primus": "^6.0.3",
+    "primus-emit": "^1.0.0",
+    "primus-spark-latency": "^0.1.1",
+    "ws": "^1.1.1"
   },
   "repository": {
     "type": "git",
@@ -47,6 +47,5 @@
     }
   ],
   "license": "LGPL-3.0",
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "grunt-contrib-uglify": "^0.9.1",
     "jade": "1.11.0",
     "lodash": "3.10.1",
-    "primus": "^6.0.3",
+    "primus": "^6.0.5",
     "primus-emit": "^1.0.0",
     "primus-spark-latency": "^0.1.1",
-    "ws": "^1.1.1"
+    "ws": "^1.1.1",
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "primus": "^6.0.5",
     "primus-emit": "^1.0.0",
     "primus-spark-latency": "^0.1.1",
-    "ws": "^1.1.1",
+    "ws": "^1.1.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,14 @@
     "primus": "3.2.1",
     "primus-emit": "0.1.2",
     "primus-spark-latency": "0.1.1",
-    "ws": "0.8.1"
+    "ws": "0.8.1",
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-concat": "^0.5.1",
+    "grunt-contrib-copy": "^0.8.0",
+    "grunt-contrib-cssmin": "^0.12.3",
+    "grunt-contrib-jade": "^0.14.1",
+    "grunt-contrib-uglify": "^0.9.1"
   },
   "repository": {
     "type": "git",
@@ -41,12 +48,5 @@
   ],
   "license": "LGPL-3.0",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-cssmin": "^0.12.3",
-    "grunt-contrib-jade": "^0.14.1",
-    "grunt-contrib-uglify": "^0.9.1"
   }
 }

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -128,7 +128,7 @@ angular.module('netStatsApp.filters', [])
 })
 .filter('nodeVersion', function($sce) {
 	return function(version) {
-		if(typeof version !== 'undefined')
+		if(version)
 		{
 			var tmp = version.split('/');
 
@@ -463,7 +463,7 @@ angular.module('netStatsApp.filters', [])
 		var tooltip = [];
 		var string = '';
 
-		if(node.info.node !== '' && typeof node.info.node !== 'undefined') {
+		if(node.info.node) {
 			var eth_version = node.info.node.split('/');
 
 			if(eth_version[1][0] !== 'v' && eth_version[1][2] !== '.')

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -139,19 +139,19 @@ angular.module('netStatsApp.filters', [])
 				tmp[0] = 'pyeth';
 			}
 
-			if(tmp[1][0] !== 'v' && tmp[1][2] !== '.')
+			if(tmp[1] && tmp[1][0] !== 'v' && tmp[1][2] !== '.')
 			{
 				tmp.splice(1,1);
 			}
 
-			if(tmp[2] === 'Release'){
+			if(tmp[2] && tmp[2] === 'Release'){
 				tmp.splice(2,1);
 			}
 
-			if(tmp[2].indexOf('Linux') === 0)
+			if(tmp[2] && tmp[2].indexOf('Linux') === 0)
 				tmp[2] = 'linux';
 
-			if(tmp[2].indexOf('Darwin') === 0)
+			if(tmp[2] && tmp[2].indexOf('Darwin') === 0)
 				tmp[2] = 'darwin';
 
 			return $sce.trustAsHtml(tmp.join('/'));
@@ -466,16 +466,18 @@ angular.module('netStatsApp.filters', [])
 		if(node.info.node) {
 			var eth_version = node.info.node.split('/');
 
-			if(eth_version[1][0] !== 'v' && eth_version[1][2] !== '.')
-			{
-				eth_version.splice(1,1);
-			}
+      if(eth_version[1]){
+			  if(eth_version[1][0] !== 'v' && eth_version[1][2] !== '.')
+			  {
+				  eth_version.splice(1,1);
+			  }
 
-			string = "<b>" + node.info.node + "</b>";
-			tooltip.push(string);
+			  string = "<b>" + node.info.node + "</b>";
+			  tooltip.push(string);
 
-			string = "Version: <b>" + (eth_version[1]) + "</b>";
-			tooltip.push(string);
+			  string = "Version: <b>" + (eth_version[1]) + "</b>";
+			  tooltip.push(string);
+      }
 		}
 
 		if(node.info.net !== '') {


### PR DESCRIPTION
- Fixed client-side error spam when a node has non-standard node info
- updated ws dependencies (old deps were causing server-side ws errors on recently updated installs of ubuntu)
- disabled source mapping (was causing build troubles)