### PR TITLE
Support run eth-netstats with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node
+
+RUN git clone https://github.com/cubedro/eth-netstats /eth-netstats
+WORKDIR /eth-netstats
+RUN npm install
+RUN npm install -g grunt-cli
+RUN grunt
+
+CMD ["npm", "start"]


### PR DESCRIPTION
I add Dockerfile so it easy to deploy with docker's user

It  can be used with compose file:

```yml
version: '3'
services:
  netstats:
    ports:
     - 3000:3000
    environment:
     - WS_SECRET=SgePVom6GQLv0nYnil9O3qAnCM5K2p6T
    build: .
```

