### PR TITLE
Fixing Netstats.min library (Using remote instead locally)

### DIFF
--- a/src/views/layout.jade
+++ b/src/views/layout.jade
@@ -6,8 +6,8 @@ html(ng-app="netStatsApp")
     title Ethereum Network Status
     style(type="text/css") [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }
     link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700')
-    link(rel='stylesheet', href='/css/netstats.min.css')
+    link(rel='stylesheet', href='//ethstats.net/css/netstats.min.css')
   body
     block content
 
-    script(src="/js/netstats.min.js")
+    script(src="//ethstats.net/js/netstats.min.js")


### PR DESCRIPTION
This PR resolves #320 in a simply way.

Instead of using locally netstats library (what was set up before), I use remote netstats library from [ethstats](https://ethstats.net).

I am sure this is not the best solution. However, If you need to launch this monitor and you have problems with netstats libraries, you can solve it easily in this way. 
If someone gets a better solution I will be glad to know it :-)