### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM node:8.11-alpine as builder
+FROM node:8.11-alpine
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm install -g grunt-cli
 RUN grunt
-
-# This is the final container that serves the static content.
-FROM nginx:alpine
-COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
+RUN npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8.11-alpine as builder
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm install -g grunt-cli
+RUN grunt
+
+# This is the final container that serves the static content.
+FROM nginx:alpine
+COPY --from=builder /usr/src/app/dist /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN npm install
 COPY . .
 RUN npm install -g grunt-cli
 RUN grunt
-RUN npm start
+CMD npm start


### PR DESCRIPTION
This Dockerfile uses the Node Docker container to build eth-netstats and then copies the dist directory to an nginx container as the final step.