### PR TITLE
Receive enodes over websockets and serve them at /static-nodes.json

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -2,6 +2,8 @@ var express = require('express');
 var app = express();
 var path = require('path');
 var bodyParser = require('body-parser');
+var fs = require('fs');
+const { STATIC_NODES_JSON } = require('../app.js');
 
 // view engine setup
 app.set('views', path.join(__dirname, (process.env.LITE === 'true' ? '../src-lite/views' : '../src/views')));
@@ -12,6 +14,14 @@ app.use(express.static(path.join(__dirname, (process.env.LITE === 'true' ? '../d
 
 app.get('/', function(req, res) {
   res.render('index');
+});
+
+app.get('/static-nodes.json', function(req, res) {
+  var stream = fs.createReadStream(STATIC_NODES_JSON, {bufferSize: 64 * 1024})
+  stream.on('error', () => {
+    res.send('[]');
+  });
+  stream.pipe(res);
 });
 
 // catch 404 and forward to error handler


### PR DESCRIPTION
Intention is to make `eth-netstats` a source of Auto-updated Enode List
to use with Nethermind of example.

How it works: The enode-reporter is a separate NodeJS app that is designed to run
besides Nethermind and query the Nethermind client via JsonRPC. Then it publishes enode and name
on the `enode` channel via Websockets connection with `eth-netstats`. Here we collect all
enodes (keyed on node id for deduplication purposes) and store them
in the format of `static-nodes.json`, one of the config
files for Nethermind.

The file is available at `/static-nodes.json`.